### PR TITLE
add metainfo.xml to vcs and added x-checer for auto-updates

### DIFF
--- a/com.scanoss.sbom-workbench.metainfo.xml
+++ b/com.scanoss.sbom-workbench.metainfo.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.scanoss.sbom-workbench</id>
+
+  <developer id="com.scanoss">
+    <name>SCANOSS</name>
+  </developer>
+  <developer_name>SCANOSS</developer_name>
+
+  <name>SCANOSS SBOM Workbench</name>
+  <summary>Graphical user interface to scan and audit your source code</summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0-only</project_license>
+
+  <categories>
+    <category>Development</category>
+  </categories>
+
+  <keywords>
+    <keyword>SBOM</keyword>
+    <keyword>SCA</keyword>
+    <keyword>security</keyword>
+    <keyword>licenses</keyword>
+    <keyword>scanoss</keyword>
+  </keywords>
+
+  <url type="homepage">https://github.com/scanoss/sbom-workbench</url>
+  <url type="bugtracker">https://github.com/scanoss/sbom-workbench/issues</url>
+  <url type="vcs-browser">https://github.com/scanoss/sbom-workbench</url>
+  <url type="help">https://github.com/scanoss/sbom-workbench#readme</url>
+
+  <launchable type="desktop-id">com.scanoss.sbom-workbench.desktop</launchable>
+
+  <description>
+    <p>
+      The SBOM Workbench is a graphical user interface to scan and audit source code using the SCANOSS API.
+    </p>
+  </description>
+
+  <screenshots>
+    <screenshot type="default">
+      <image>https://download.scanoss.com/sbom-workbench/flathub/scanoss_sbom-workbench_01.png</image>
+      <caption>Main dashboard</caption>
+    </screenshot>
+  </screenshots>
+
+  <content_rating type="oars-1.1"/>
+
+  <releases>
+    <release version="1.21.0" date="2025-05-07">
+      <url type="release-notes">https://github.com/scanoss/sbom-workbench/releases/tag/v1.21.0</url>
+      <description>
+        <p>Upgraded scanoss.js SDK, added new package-lock.json v1 parser and minor fixes.</p>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/com.scanoss.sbom-workbench.metainfo.xml
+++ b/com.scanoss.sbom-workbench.metainfo.xml
@@ -48,6 +48,12 @@
   <content_rating type="oars-1.1"/>
 
   <releases>
+    <release version="1.25.0" date="2025-11-05">
+      <url type="release-notes">https://github.com/scanoss/sbom-workbench/releases/tag/v1.25.0</url>
+      <description>
+        <p>Upgraded scanoss.js to v0.26.0, added fh2 support and other minor features.</p>
+      </description>
+    </release>
     <release version="1.21.0" date="2025-05-07">
       <url type="release-notes">https://github.com/scanoss/sbom-workbench/releases/tag/v1.21.0</url>
       <description>

--- a/com.scanoss.sbom-workbench.yml
+++ b/com.scanoss.sbom-workbench.yml
@@ -11,7 +11,7 @@ rename-desktop-file: scanoss-workbench.desktop
 finish-args:
   - "--share=ipc"
   - "--socket=wayland"
-  - "--socket=x11"
+  - "--socket=fallback-x11"
   - "--socket=pulseaudio"
   - "--share=network"
   - "--device=dri"

--- a/com.scanoss.sbom-workbench.yml
+++ b/com.scanoss.sbom-workbench.yml
@@ -1,41 +1,59 @@
 app-id: com.scanoss.sbom-workbench
 base: org.electronjs.Electron2.BaseApp
-base-version: "23.08"
+base-version: "24.08"
 runtime: org.freedesktop.Platform
-runtime-version: "23.08"
+runtime-version: "24.08"
 sdk: org.freedesktop.Sdk
 separate-locales: false
 command: com.scanoss.sbom-workbench
 rename-desktop-file: scanoss-workbench.desktop
+
 finish-args:
   - "--share=ipc"
+  - "--socket=wayland"
   - "--socket=x11"
   - "--socket=pulseaudio"
-  - "--share=network"  
-  - "--device=dri"    
+  - "--share=network"
+  - "--device=dri"
   - "--filesystem=home:rw"
+
 modules:
   - name: sbom-workbench
     buildsystem: simple
     build-commands:
-      - chmod +x sbom-workbench-1.21.0-linux-x86_64.AppImage
-      - ./sbom-workbench-1.21.0-linux-x86_64.AppImage --appimage-extract
+      # Handle whatever AppImage the checker pulls
+      - chmod +x *.AppImage
+      - ./*.AppImage --appimage-extract
 
       - install -dm755 "${FLATPAK_DEST}/bin" "${FLATPAK_DEST}/lib/sbom-workbench"
-      - cp -r squashfs-root/* "${FLATPAK_DEST}/lib/sbom-workbench"      
+      - cp -r squashfs-root/* "${FLATPAK_DEST}/lib/sbom-workbench"
 
       - install -Dm644 "scanoss-logo.jpg" "${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/com.scanoss.sbom-workbench.png"
       - install -Dm755 "run.sh" "${FLATPAK_DEST}/bin/com.scanoss.sbom-workbench"
-      - desktop-file-install --dir="${FLATPAK_DEST}/share/applications" --remove-key=X-AppImage-Version --set-key=Exec --set-value=com.scanoss.sbom-workbench --set-key=Icon --set-value=com.scanoss.sbom-workbench squashfs-root/scanoss-workbench.desktop
 
-      - install -Dm644 -t ${FLATPAK_DEST}/share/metainfo com.scanoss.sbom-workbench.metainfo.xml
+      - desktop-file-install \
+          --dir="${FLATPAK_DEST}/share/applications" \
+          --remove-key=X-AppImage-Version \
+          --set-key=Exec --set-value=com.scanoss.sbom-workbench \
+          --set-key=Icon --set-value=com.scanoss.sbom-workbench \
+          squashfs-root/scanoss-workbench.desktop
+
+      - install -Dm644 -t "${FLATPAK_DEST}/share/metainfo" com.scanoss.sbom-workbench.metainfo.xml
+
     sources:
       - type: file
         url: https://github.com/scanoss/sbom-workbench/releases/download/v1.21.0/sbom-workbench-1.21.0-linux-x86_64.AppImage
         sha256: 1ffb4b9e911ade147f07e008261a6aecdb32fd6e48f964869f3d5932dd7732de
+        x-checker-data:
+          type: github
+          repo: scanoss/sbom-workbench
+          asset_regex: '^sbom-workbench-([0-9.]+)-linux-x86_64\.AppImage$'
+          tag-pattern: '^v?([0-9.]+)$'
+          version-template: '$1'
+
       - type: file
-        url: https://download.scanoss.com/sbom-workbench/flathub/com.scanoss.sbom-workbench.metainfo.xml
-        sha256: dbc3b0914f7587f3432d9b0dac2201e5a0defc3a18496ec87086d596f5035086
+        path: com.scanoss.sbom-workbench.metainfo.xml
+
       - type: file
         path: scanoss-logo.jpg
       - type: file

--- a/com.scanoss.sbom-workbench.yml
+++ b/com.scanoss.sbom-workbench.yml
@@ -10,33 +10,27 @@ rename-desktop-file: scanoss-workbench.desktop
 
 finish-args:
   - "--share=ipc"
-  - "--socket=wayland"
-  - "--socket=fallback-x11"
+  - "--device=dri"
+  - "--socket=x11"
   - "--socket=pulseaudio"
   - "--share=network"
-  - "--device=dri"
   - "--filesystem=home:rw"
 
 modules:
   - name: sbom-workbench
     buildsystem: simple
     build-commands:
-      # Handle whatever AppImage the checker pulls
       - chmod +x *.AppImage
       - ./*.AppImage --appimage-extract
 
       - install -dm755 "${FLATPAK_DEST}/bin" "${FLATPAK_DEST}/lib/sbom-workbench"
       - cp -r squashfs-root/* "${FLATPAK_DEST}/lib/sbom-workbench"
 
-      - install -Dm644 "scanoss-logo.jpg" "${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/com.scanoss.sbom-workbench.png"
+      - install -Dm644 "scanoss-logo.jpg" "${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/com.scanoss.sbom-workbench.jpg"
+
       - install -Dm755 "run.sh" "${FLATPAK_DEST}/bin/com.scanoss.sbom-workbench"
 
-      - desktop-file-install \
-          --dir="${FLATPAK_DEST}/share/applications" \
-          --remove-key=X-AppImage-Version \
-          --set-key=Exec --set-value=com.scanoss.sbom-workbench \
-          --set-key=Icon --set-value=com.scanoss.sbom-workbench \
-          squashfs-root/scanoss-workbench.desktop
+      - desktop-file-install --dir="${FLATPAK_DEST}/share/applications" --remove-key=X-AppImage-Version --set-key=Exec --set-value=com.scanoss.sbom-workbench --set-key=Icon --set-value=com.scanoss.sbom-workbench squashfs-root/scanoss-workbench.desktop
 
       - install -Dm644 -t "${FLATPAK_DEST}/share/metainfo" com.scanoss.sbom-workbench.metainfo.xml
 
@@ -56,5 +50,6 @@ modules:
 
       - type: file
         path: scanoss-logo.jpg
+
       - type: file
         path: run.sh

--- a/com.scanoss.sbom-workbench.yml
+++ b/com.scanoss.sbom-workbench.yml
@@ -26,7 +26,7 @@ modules:
       - install -dm755 "${FLATPAK_DEST}/bin" "${FLATPAK_DEST}/lib/sbom-workbench"
       - cp -r squashfs-root/* "${FLATPAK_DEST}/lib/sbom-workbench"
 
-      - install -Dm644 "scanoss-logo.jpg" "${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/com.scanoss.sbom-workbench.jpg"
+      - install -Dm644 "scanoss-logo.jpg" "${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/com.scanoss.sbom-workbench.png"
 
       - install -Dm755 "run.sh" "${FLATPAK_DEST}/bin/com.scanoss.sbom-workbench"
 


### PR DESCRIPTION
### This PR vendors the AppStream metadata and enables automatic updates via Flathub’s external-data-checker.

### Changes included:

- Added com.scanoss.sbom-workbench.metainfo.xml directly into the Flathub repo (no more external hosting).
- Updated com.scanoss.sbom-workbench.yaml:
- switched AppStream source from url: to local path:
- added x-checker-data to auto-track GitHub releases and update AppImage URL + sha256 automatically
- ensured icon, desktop file, and launcher are correctly installed

### Impact:

- Future releases are now zero effort: publish a GitHub release → Flathub auto-opens a PR with the new version + hash.
- App metadata (screenshots, release notes, changelog) is controlled from the Flathub repo.